### PR TITLE
Multi window & scene support

### DIFF
--- a/Cellua/Api/Common/SceneObject.cs
+++ b/Cellua/Api/Common/SceneObject.cs
@@ -2,11 +2,11 @@
 
 namespace Cellua.Api.Common
 {
-    public class SceneApi
+    public class SceneObject
     {
         public Scene Scene;
 
-        public SceneApi(Scene scene)
+        public SceneObject(Scene scene)
         {
             Scene = scene;
         }

--- a/Cellua/Api/Common/WindowApi.cs
+++ b/Cellua/Api/Common/WindowApi.cs
@@ -1,45 +1,68 @@
 ﻿using System;
+using Cellua.Simulation;
 using SFML.Graphics;
+using SFML.System;
+using SFML.Window;
 
 namespace Cellua.Api.Common
 {
+    public class WindowObject
+    {
+        public readonly RenderWindow Window;
+        public readonly Action<WindowObject> DisplayFunc;
+        public double Dt;
+        public readonly Clock Clock;
+        public readonly SceneObject Scene;
+        
+        public WindowObject(RenderWindow renderWindow, Action<WindowObject> displayFunc)
+        {
+            Window = renderWindow;
+            DisplayFunc = displayFunc;
+            Window.Closed += (_, _) =>
+            {
+                Window.Close();
+            };
+            Clock = new();
+            Scene = new SceneObject(new Scene(new SceneInfo(renderWindow.Size.X)));
+        }
+
+        public SceneObject GetScene() => Scene;
+
+        public bool IsOpen() => Window.IsOpen;
+
+        public void SetTitle(string title) => Window.SetTitle(title);
+
+        public void Display() => DisplayFunc(this);
+
+        public void Close() => Window.Close();
+
+        public void Clear() => Window.Clear();
+
+        public void SetFramerateLimit(uint framerate) => Window.SetFramerateLimit(framerate);
+
+        public double GetFramerate() => 1.0 / Dt;
+    }
+    
     public class WindowApi
     {
         public RenderWindow Window;
+        public readonly Action<WindowObject> DisplayFunc;
 
-        public Action DisplayFunc;
-
-        public WindowApi(RenderWindow window, Action displayFunc)
+        public WindowApi(RenderWindow window, Action<WindowObject> displayFunc)
         {
             Window = window;
             DisplayFunc = displayFunc;
         }
 
-        public bool IsOpen()
+        public WindowObject NewWindow(uint size, string title)
         {
-            return Window.IsOpen;
-        }
-        
-        public void SetTitle(string title)
-        {
-            Window.SetTitle(title);
-        }
-
-        public void Display()
-        {
-            DisplayFunc();
-        }
-        public void Close()
-        {
-            Window.Close();
-        }
-        public void Clear()
-        {
-            Window.Clear();
-        }
-        public void SetFramerateLimit(uint framerate)
-        {
-            Window.SetFramerateLimit(framerate);
+            return new WindowObject(
+                new RenderWindow(
+                    new VideoMode(size, size),
+                    title
+                ),
+                DisplayFunc
+            );
         }
     }
 }

--- a/Cellua/Api/Lua/ScriptManager.cs
+++ b/Cellua/Api/Lua/ScriptManager.cs
@@ -16,8 +16,9 @@ namespace Cellua.Api.Lua
             UserData.RegisterType<RandomApi>();
             UserData.RegisterType<RandomBool>();
             UserData.RegisterType<WindowApi>();
-            UserData.RegisterType<SceneApi>();
+            UserData.RegisterType<SceneObject>();
             UserData.RegisterType<SystemApi>();
+            UserData.RegisterType<WindowObject>();
         }
     }
     
@@ -28,11 +29,9 @@ namespace Cellua.Api.Lua
         public readonly RandomApi RandomApi;
         public readonly WindowApi WindowApi;
         public readonly SystemApi SystemApi;
-        public SceneApi SceneApi;
 
-        public ScriptManager(Scene scene, RenderWindow window, Action renderFunc)
+        public ScriptManager(Scene scene, RenderWindow window, Action<WindowObject> renderFunc)
         {
-            SceneApi = new SceneApi(scene);
             RandomApi = new RandomApi();
             WindowApi = new WindowApi(window, renderFunc);
             SystemApi = new SystemApi();
@@ -47,7 +46,6 @@ namespace Cellua.Api.Lua
                 {
                     ["Random"] = RandomApi,
                     ["Window"] = WindowApi,
-                    ["Scene"] = SceneApi,
                     ["System"] = SystemApi
                 }
             };

--- a/Cellua/ApiSpec/SceneObject.lua
+++ b/Cellua/ApiSpec/SceneObject.lua
@@ -1,4 +1,5 @@
-﻿Scene = {}
+﻿---@class SceneObject
+SceneObject = {}
 
 --- Change color of the tile
 ---@param x number x position of the tile
@@ -7,16 +8,16 @@
 ---@param g number Green value of the tile
 ---@param b number Blue value of the tile
 ---@param a number Alpha value of the tile
-function Scene.SetColor(x, y, r, g, b, a) end
+function SceneObject.SetColor(x, y, r, g, b, a) end
 
 --- Change type id of the tile
 ---@param x number x position of the tile
 ---@param y number y position of the tile
 ---@param typeid number type id to set
-function Scene.SetTileTypeId(x, y, typeid) end
+function SceneObject.SetTileTypeId(x, y, typeid) end
 
 --- Returns type id of the tile
 ---@param x number x position of the tile
 ---@param y number y position of the tile
 ---@return number tile type id
-function Scene.GetTileTypeId(x, y) end
+function SceneObject.GetTileTypeId(x, y) end

--- a/Cellua/ApiSpec/Window.lua
+++ b/Cellua/ApiSpec/Window.lua
@@ -1,22 +1,7 @@
 ﻿Window = {}
 
---- Changes the title of the Cellua Window
+--- Creates a new window
+---@param size number
 ---@param title string
-function Window.SetTitle(title) end
-
---- Closes the Cellua window
-function Window.Close() end
-
---- Clears the Cellua screen
-function Window.Clear() end
-
---- Changes the framerate limit
----@param limit number
-function Window.SetFramerateLimit(limit) end
-
---- Returns true if the window isOpened
----@return boolean
-function Window.IsOpen() end
-
---- Displays the scene
-function Window.Display() end
+---@return WindowObject
+function Window.NewWindow(size, title) end

--- a/Cellua/ApiSpec/WindowObject.lua
+++ b/Cellua/ApiSpec/WindowObject.lua
@@ -1,0 +1,31 @@
+﻿---@class WindowObject
+WindowObject = {}
+
+--- Changes the title of the window
+---@param title string
+function WindowObject.SetTitle(title) end
+
+--- Closes the window
+function WindowObject.Close() end
+
+--- Clears the window screen
+function WindowObject.Clear() end
+
+--- Changes the framerate limit
+---@param limit number
+function WindowObject.SetFramerateLimit(limit) end
+
+--- Returns true if the window isOpened
+---@return boolean
+function WindowObject.IsOpen() end
+
+--- Displays the scene
+function WindowObject.Display() end
+
+--- Returns the framerate
+---@return number
+function WindowObject.GetFramerate() end
+
+--- Returns a SceneObject
+---@return SceneObject
+function WindowObject.GetScene() end

--- a/Cellua/Program.cs
+++ b/Cellua/Program.cs
@@ -1,8 +1,7 @@
-﻿using System;
+﻿using Cellua.Api.Common;
 using Api = Cellua.Api;
 using Cellua.Simulation;
 using SFML.Graphics;
-using SFML.System;
 using SFML.Window;
 
 var scene = new Scene(new SceneInfo(800));
@@ -14,30 +13,17 @@ window.Clear();
 Texture worldTexture = new(scene.SceneInfo.Size, scene.SceneInfo.Size);
 Sprite worldSprite = new(worldTexture);
 
-Clock clock = new();
-var dt = 0.0;
-
-#region UI
-var framerateText = new Text("", new Font("res/OpenSans-Regular.ttf"));
-#endregion
-
-#region Events
-window.Closed += (_, _) => { window.Close(); };
-#endregion
-
-void RenderFunc()
+void RenderFunc(WindowObject wo)
 {
-    framerateText.DisplayedString = Math.Round(1.0 / dt) + " FPS";
-    window.DispatchEvents();
+    wo.Window.DispatchEvents();
 
-    scene.UpdatePixels(true);
-    scene.UpdateTexture(worldTexture);
+    wo.Scene.Scene.UpdatePixels(true);
+    wo.Scene.Scene.UpdateTexture(worldTexture);
 
-    window.Draw(worldSprite);
-    window.Draw(framerateText);
+    wo.Window.Draw(worldSprite);
 
-    window.Display();
-    dt = clock.Restart().AsSeconds();
+    wo.Window.Display();
+    wo.Dt = wo.Clock.Restart().AsSeconds();
 }
 
 Api.Lua.ScriptManagerUtils.RegisterTypes();


### PR DESCRIPTION
# About
This PR contain(s) changes that adds support for multi window & scene support that closes #3  
this contains breaking API changes that can be migrated easily.

# Migration
## Window Api
All methods inside `Window` are now transferred to `WindowObject` class, for example
````lua
--- old
Window.Clear()

--- new
w = Window.NewWindow(800, "Testing Window")
w.Clear()
`````
## Scene Api
All methods inside `Scene` are now transferred to `SceneObject` class, an instance of this class resides in `WindowObject` and can be access using `WindowObject.GetScene` method

````lua
--- old
Scene.SetColor(i, i, 255, 0, 0, 255)

--- new
w = Window.NewWindow(800, "Testing Window")
s = Window.GetScene()
s.SetColor(200, 200, 255, 0, 0, 255)
```` 

