### PR TITLE
Read paramaters from package.json

### DIFF
--- a/Cellua/Core/PackageManager/PackageManager.cs
+++ b/Cellua/Core/PackageManager/PackageManager.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Cellua.Core.PackageManager
+{
+    public class Config
+    {
+        [JsonRequired]
+        public string Main;
+
+        public string[] ModulePaths;
+    }
+    public class PackageManager
+    {
+        public Config Config = new();
+        
+        public void LoadConfiguration(string config)
+        {
+            Config = JsonConvert.DeserializeObject<Config>(config);
+        }
+
+        public void LoadFromFile(string location)
+        {
+            LoadConfiguration(System.IO.File.ReadAllText(location));
+        }
+    }
+}

--- a/Cellua/Program.cs
+++ b/Cellua/Program.cs
@@ -1,4 +1,6 @@
-﻿using Cellua.Api.Common;
+﻿using System;
+using Cellua.Api.Common;
+using Cellua.Core.PackageManager;
 using Api = Cellua.Api;
 using Cellua.Simulation;
 using SFML.Graphics;
@@ -12,6 +14,18 @@ window.Clear();
 
 Texture worldTexture = new(scene.SceneInfo.Size, scene.SceneInfo.Size);
 Sprite worldSprite = new(worldTexture);
+
+
+PackageManager pkgManger = new();
+try
+{
+    pkgManger.LoadFromFile("./package.json");
+}
+catch (Exception e)
+{
+    Console.WriteLine("Unable to find package.json in the current directory", e);
+    throw;
+}
 
 void RenderFunc(WindowObject wo)
 {
@@ -29,8 +43,17 @@ void RenderFunc(WindowObject wo)
 Api.Lua.ScriptManagerUtils.RegisterTypes();
 MoonSharp.Interpreter.Script.WarmUp();
 Api.Lua.ScriptManager sm = new(scene, window, RenderFunc);
-sm.LoadFromFolder("./scripts");
+
+try
+{
+    sm.LoadMainFile(pkgManger.Config.Main);
+}
+catch (Exception e)
+{
+    Console.WriteLine("Unable to load main file", e);
+    throw;
+}
 
 
-var s = sm.NewScriptWithGlobals();
-sm.RunScript(s, "main.lua");
+var s = sm.NewScriptWithGlobals(pkgManger.Config.ModulePaths);
+sm.RunMainScript(s, "main.lua");


### PR DESCRIPTION
# About
This PR contains commit(s) that adds config file support and support for including modules inside lua that closes #6 
This contains breaking changes that effect older projects.

# Migration
Cellua no longer automatically executes `./scripts/main.lua` instead it looks for a file named `package.json` in the current directory and executes the lua file in the location pointed by the file
````json
{
    "Main": "./scripts/main.lua",
    "ModulePaths": ["./scripts/module/math.lua"] // Optional: required if using lua modules
}
```` 


